### PR TITLE
Fix Python cache ignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Python関連
 asianese_translator/venv/
 __pycache__/
-*.__pycache__
+**/__pycache__/
 
 #エディタ/OS関連
 .DS_Store


### PR DESCRIPTION
## Summary
- fix the `.gitignore` entry for Python cache directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68403bfb1668832baad16e08293a39fe